### PR TITLE
outer should work on multi-dimension array; 

### DIFF
--- a/src/outer.jl
+++ b/src/outer.jl
@@ -1,11 +1,15 @@
 
 """
+The outer product of two arrays, returning a matrix `A` with dimension `hcat(size(x), size(y))`.
+
 # Arguments
 * `x`, `y`: First and second arguments for function `FUN`. Typically a vector.
 * `FUN`: a function to use on the outer products
-* `args...`: optional *keywords* arguments passed to `FUN`
-        
+* `args`: optional arguments to `FUN`
+* `kwargs...`: optional keywords arguments passed to `FUN`
+
 Example:
+```
 outer(1:4, 1:4)
 outer(1:4, 1:4, +)
 outer(1:4, 1:4, (x, y) -> x^2 + y^2)
@@ -13,15 +17,13 @@ outer(1:4, 1:4, (x, y) -> x^2 + y^2)
 function tmp(x, y; z=1.0)
     x^2 + y^2 + z
 end
-outer(1:4, 1:4, FUN=tmp, z=2.0)
+outer(1:4, 1:4, tmp, z=2.0)
+function tmp2(x, y, z=1.0)
+    x^2 + y^2 + z
+end
+outer(1:4, 1:4, tmp2, 2.0)
+```
 """
-
-function outer(x::AbstractVector, y::AbstractVector, FUN::Function = *, args...)
-    [FUN(i, j; args...) for i in x, j in y]
+function outer(x::AbstractArray, y::AbstractArray, FUN::Function = *, args...; kwargs...)
+    [FUN(i, j, args...; kwargs...) for i in x, j in y]
 end
-
-function outer(x::AbstractVector, y::AbstractVector; FUN::Function = *, args...)
-    outer(x, y, FUN, args...)
-end
-
-

--- a/src/outer.jl
+++ b/src/outer.jl
@@ -24,6 +24,7 @@ end
 outer(1:4, 1:4, tmp2, 2.0)
 ```
 """
-function outer(x::AbstractArray, y::AbstractArray, FUN::Function = *, args...; kwargs...)
+function outer(x::AbstractArray, y::AbstractArray, FUN::Function, args...; kwargs...)
     [FUN(i, j, args...; kwargs...) for i in x, j in y]
 end
+outer(x::AbstractArray, y::AbstractArray, args...; FUN::Function=*, kwargs...) = outer(x, y, FUN, args...; kwargs...)


### PR DESCRIPTION
I made some changes on `outer` function to allow both arguments and keywords arguments to `FUN`.
However this disables to pass `FUN` as a keyword argument. There is some problem to allow both `FUN` and `kwargs` to be keyword arguments. Needs some investigation here.
How do you think? @mingsnu 
