### PR TITLE
Seq function

### DIFF
--- a/src/RFlavor.jl
+++ b/src/RFlavor.jl
@@ -20,7 +20,8 @@ export rep, rep_len,
     duplicated,
     findinterval,
     matrix,
-    List, list, unlist, lapply, as_list
+    List, list, unlist, lapply, as_list,
+    seq
 
 
 include("rep.jl")
@@ -35,4 +36,5 @@ include("duplicated.jl")
 include("findinterval.jl")
 include("matrix.jl")
 include("List.jl")
+include("seq.jl")
 end # module

--- a/src/seq.jl
+++ b/src/seq.jl
@@ -1,0 +1,40 @@
+"""
+    seq(from, to, by, length)
+    seq_len(n)
+    seq_along(x)
+
+## Description
+Implementation for `seq` function in R. `seq` supplies a consistent sequence generating function in julia, so that users don't need to switch between `linspace` and `range` functions when generating sequences.
+
+## Value
+The function returns a vector.
+
+## Example
+```
+seq(0, 1, length = 11)
+seq(1, 9, by = 2)
+seq(1, 5, by =0.4)
+seq(1, -1, length=10)
+seq_len(10)
+seq_along(rand(10))
+```
+"""
+
+function seq(from::Real, to::Real, by::Real)
+    collect(from:by:to)
+end
+
+function seq(from::Real, to::Real; length::Integer=2, by::Real = (to - from)/(length -1))
+    collect(from:by:to)
+end
+
+function seq_len(n::Integer)
+    collect(1:n)
+end
+
+function seq_along(x::AbstractVector)
+    collect(1:length(x))
+end
+
+
+                                            


### PR DESCRIPTION
Implementation for `seq` function in R. `seq` supplies a consistent sequence generating function in julia, so that users don't need to switch between `linspace` and `range` functions when
generating sequences. 

You can merge it if you think it is necessary.
